### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,5 +1,7 @@
 name: Validate Pull Request
 on: pull_request
+permissions:
+  contents: read
 
 jobs:
   valdiate_pr_title:


### PR DESCRIPTION
Potential fix for [https://github.com/tomarra/tomarra.github.io/security/code-scanning/9](https://github.com/tomarra/tomarra.github.io/security/code-scanning/9)

To fix this problem, add a `permissions:` block limiting token access as much as possible. Review the jobs:  
- `valdiate_pr_title` runs `amannn/action-semantic-pull-request`, which only requires reading pull request data.  
- `validate_build` and `validate_spelling` checkout code and build/run checks, but do not push changes or modify the repo or PRs.  

Therefore, the minimal permissions required are likely `contents: read`. If, in the future, a job/pipeline needs to comment on PRs or push commits, the permissions can be further expanded as needed for that job only.

The best way to fix is to add the minimal `permissions:` block at the root level of the workflow file, i.e. after the `name:` and `on:` lines (so it will apply to all jobs). Add:
```yaml
permissions:
  contents: read
```
If more specific permissions are needed for individual jobs, those could later be extended in their respective blocks.

No new methods or imports are required, only the insertion of one YAML block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
