### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/site_link_check.yaml
+++ b/.github/workflows/site_link_check.yaml
@@ -4,6 +4,9 @@ on:
     - cron: "0 0 * * 0"
 
 name: Site Link Check
+permissions:
+  contents: read
+  issues: write
 
 jobs:
   linkChecker:


### PR DESCRIPTION
Potential fix for [https://github.com/tomarra/tomarra.github.io/security/code-scanning/6](https://github.com/tomarra/tomarra.github.io/security/code-scanning/6)

To fix this problem, we should add an explicit `permissions` key to the workflow YAML file. This can be done at the root level (so all jobs inherit it unless overridden), or just for the specific job. In this case, the `linkChecker` job only checks out code (needs `contents: read`) and potentially creates issues (needs `issues: write`). Add the following block **before** the `jobs:` key after the `name: Site Link Check` line, specifying only what's needed: `contents: read` and `issues: write`. No other imports or code changes are necessary outside this YAML edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
